### PR TITLE
Improve promo canvas lesson flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -3146,20 +3146,39 @@ plt.close('all')
     padWrap.className = 'cderive-pad-wrap';
     canvasCol.appendChild(padWrap);
 
+    const ghostLayer = document.createElement('div');
+    ghostLayer.className = 'cderive-ghost-layer';
+    padWrap.appendChild(ghostLayer);
+
     const canvas = document.createElement('canvas');
     canvas.className = 'cderive-pad';
     canvas.width = 1400;
     canvas.height = 900;
     padWrap.appendChild(canvas);
 
+    const objectLayer = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    objectLayer.setAttribute('class', 'cderive-object-layer');
+    objectLayer.setAttribute('viewBox', '0 0 1400 900');
+    objectLayer.setAttribute('aria-hidden', 'true');
+    padWrap.appendChild(objectLayer);
+
     let recognitionTimer = null;
+    let objectTimer = null;
     let lastRecognizedStrokeCount = 0;
     let busy = false;
+    let solvedCanvasReady = false;
+    let suppressStrokeChange = false;
+    let detectedObjects = [];
     const RECOGNITION_DEBOUNCE_MS = 1200;
+    const OBJECT_DEBOUNCE_MS = 450;
 
     const dc = new DrawingCanvas(canvas, {
       transparentBg: true,
-      onStrokeChange: function () { scheduleRecognition(); },
+      onStrokeChange: function () {
+        if (suppressStrokeChange) return;
+        if (solvedCanvasReady) scheduleObjectRecognition();
+        else scheduleRecognition();
+      },
       onEraseEnd: function () { lastRecognizedStrokeCount = -1; }
     });
 
@@ -3179,8 +3198,14 @@ plt.close('all')
     clearBtn.addEventListener('click', () => {
       dc.clear();
       lastRecognizedStrokeCount = 0;
-      recognizedLines = [];
-      renderLinesPanel();
+      detectedObjects = [];
+      renderObjectOverlay();
+      if (solvedCanvasReady) {
+        panelStatus.textContent = 'Solved. Sketch a circle, square, or axes.';
+      } else {
+        recognizedLines = [];
+        renderLinesPanel();
+      }
     });
 
     const recognizeNowBtn = document.createElement('button');
@@ -3189,7 +3214,9 @@ plt.close('all')
     recognizeNowBtn.title = 'Force a re-read instead of waiting for the pause timer';
     recognizeNowBtn.addEventListener('click', () => {
       if (recognitionTimer) { clearTimeout(recognitionTimer); recognitionTimer = null; }
-      runRecognition();
+      if (objectTimer) { clearTimeout(objectTimer); objectTimer = null; }
+      if (solvedCanvasReady) runObjectRecognition();
+      else runRecognition();
     });
 
     const doneBtn = document.createElement('button');
@@ -3322,12 +3349,19 @@ plt.close('all')
 
     function scheduleRecognition() {
       if (busy) return;
+      if (solvedCanvasReady) return;
       if (recognitionTimer) clearTimeout(recognitionTimer);
       if (dc.strokes.length === 0) {
         // Canvas was cleared; nothing to do.
         return;
       }
       recognitionTimer = setTimeout(runRecognition, RECOGNITION_DEBOUNCE_MS);
+    }
+
+    function scheduleObjectRecognition() {
+      if (!solvedCanvasReady) return;
+      if (objectTimer) clearTimeout(objectTimer);
+      objectTimer = setTimeout(runObjectRecognition, OBJECT_DEBOUNCE_MS);
     }
 
     async function runRecognition() {
@@ -3378,7 +3412,8 @@ plt.close('all')
         if (anyMatchedTarget) {
           targetReached = true;
           doneBtn.disabled = false;
-          panelStatus.innerHTML = '<span class="cderive-target-hit">You reached the target. Click <strong>I\u2019m done</strong> when you\u2019re ready.</span>';
+          pinSolvedDerivation();
+          panelStatus.innerHTML = '<span class="cderive-target-hit">Solved. Sketch a circle, square, or axes.</span>';
         } else if (okCount > 0) {
           panelStatus.textContent = okCount + ' valid line' + (okCount === 1 ? '' : 's') +
             ' so far. Keep going.';
@@ -3394,6 +3429,216 @@ plt.close('all')
       } finally {
         busy = false;
       }
+    }
+
+    function pinSolvedDerivation() {
+      if (solvedCanvasReady) return;
+      const solvedLines = recognizedLines.filter(line => line.status === 'ok').map(line => line.latex);
+      if (solvedLines.length === 0) return;
+
+      const ghostCard = document.createElement('div');
+      ghostCard.className = 'cderive-ghost-card';
+      ghostCard.innerHTML = solvedLines.map(line => '<div class="cderive-ghost-line">$$' + esc(line) + '$$</div>').join('');
+      ghostLayer.innerHTML = '';
+      ghostLayer.appendChild(ghostCard);
+      ghostLayer.classList.add('active');
+      renderKaTeX(ghostLayer);
+
+      solvedCanvasReady = true;
+      suppressStrokeChange = true;
+      dc.clear();
+      suppressStrokeChange = false;
+      lastRecognizedStrokeCount = 0;
+      detectedObjects = [];
+      renderObjectOverlay();
+    }
+
+    function runObjectRecognition() {
+      detectedObjects = classifyCanvasObjects(dc.strokes);
+      renderObjectOverlay();
+      if (detectedObjects.length === 0) {
+        panelStatus.textContent = dc.strokes.length
+          ? 'Solved. Keep sketching.'
+          : 'Solved. Sketch a circle, square, or axes.';
+        return;
+      }
+      panelStatus.textContent = 'Detected: ' + detectedObjects.map(obj => obj.label).join(', ') + '.';
+    }
+
+    function classifyCanvasObjects(strokes) {
+      if (!strokes || strokes.length === 0) return [];
+      const objects = [];
+      const axes = detectAxes(strokes);
+      if (axes) objects.push(axes);
+
+      strokes.forEach(stroke => {
+        const shape = classifyClosedShape(stroke);
+        if (shape) objects.push(shape);
+      });
+      return objects.slice(0, 4);
+    }
+
+    function strokeBounds(stroke) {
+      const pts = (stroke && stroke.points) || [];
+      if (pts.length === 0) return null;
+      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+      pts.forEach(p => {
+        minX = Math.min(minX, p.x);
+        minY = Math.min(minY, p.y);
+        maxX = Math.max(maxX, p.x);
+        maxY = Math.max(maxY, p.y);
+      });
+      return { minX, minY, maxX, maxY, w: maxX - minX, h: maxY - minY };
+    }
+
+    function pointDistance(a, b) {
+      const dx = a.x - b.x;
+      const dy = a.y - b.y;
+      return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    function pathLength(points) {
+      let total = 0;
+      for (let i = 1; i < points.length; i++) total += pointDistance(points[i - 1], points[i]);
+      return total;
+    }
+
+    function perpendicularDistance(p, a, b) {
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      if (Math.abs(dx) < 1e-6 && Math.abs(dy) < 1e-6) return pointDistance(p, a);
+      return Math.abs(dy * p.x - dx * p.y + b.x * a.y - b.y * a.x) / Math.sqrt(dx * dx + dy * dy);
+    }
+
+    function simplifyPoints(points, epsilon) {
+      if (points.length <= 2) return points.slice();
+      let maxDist = 0;
+      let idx = 0;
+      const first = points[0];
+      const last = points[points.length - 1];
+      for (let i = 1; i < points.length - 1; i++) {
+        const dist = perpendicularDistance(points[i], first, last);
+        if (dist > maxDist) {
+          maxDist = dist;
+          idx = i;
+        }
+      }
+      if (maxDist <= epsilon) return [first, last];
+      const left = simplifyPoints(points.slice(0, idx + 1), epsilon);
+      const right = simplifyPoints(points.slice(idx), epsilon);
+      return left.slice(0, -1).concat(right);
+    }
+
+    function classifyClosedShape(stroke) {
+      const pts = (stroke && stroke.points) || [];
+      if (pts.length < 12) return null;
+      const bounds = strokeBounds(stroke);
+      if (!bounds || bounds.w < 80 || bounds.h < 80) return null;
+      const aspect = bounds.w / bounds.h;
+      if (aspect < 0.55 || aspect > 1.8) return null;
+      const closeDist = pointDistance(pts[0], pts[pts.length - 1]);
+      if (closeDist > Math.max(bounds.w, bounds.h) * 0.28) return null;
+
+      const simplified = simplifyPoints(pts, Math.max(bounds.w, bounds.h) * 0.08);
+      const cornerCount = Math.max(0, simplified.length - 1);
+      const isSquareLike = aspect > 0.72 && aspect < 1.32 && cornerCount >= 4 && cornerCount <= 6;
+      return {
+        type: isSquareLike ? 'square' : 'circle',
+        label: isSquareLike ? 'square' : 'circle',
+        bounds
+      };
+    }
+
+    function detectAxes(strokes) {
+      const lines = strokes.map(stroke => {
+        const pts = stroke.points || [];
+        if (pts.length < 2) return null;
+        const first = pts[0];
+        const last = pts[pts.length - 1];
+        const length = pathLength(pts);
+        const direct = pointDistance(first, last);
+        if (length < 180 || direct / length < 0.82) return null;
+        const dx = last.x - first.x;
+        const dy = last.y - first.y;
+        const bounds = strokeBounds(stroke);
+        if (Math.abs(dx) > Math.abs(dy) * 2.5) return { kind: 'h', first, last, bounds };
+        if (Math.abs(dy) > Math.abs(dx) * 2.5) return { kind: 'v', first, last, bounds };
+        return null;
+      }).filter(Boolean);
+
+      const horizontals = lines.filter(line => line.kind === 'h');
+      const verticals = lines.filter(line => line.kind === 'v');
+      for (const h of horizontals) {
+        for (const v of verticals) {
+          const crossesX = v.bounds.minX >= h.bounds.minX - 30 && v.bounds.maxX <= h.bounds.maxX + 30;
+          const crossesY = h.bounds.minY >= v.bounds.minY - 30 && h.bounds.maxY <= v.bounds.maxY + 30;
+          if (crossesX && crossesY) {
+            return {
+              type: 'axes',
+              label: 'coordinate axes',
+              h,
+              v,
+              bounds: {
+                minX: Math.min(h.bounds.minX, v.bounds.minX),
+                minY: Math.min(h.bounds.minY, v.bounds.minY),
+                maxX: Math.max(h.bounds.maxX, v.bounds.maxX),
+                maxY: Math.max(h.bounds.maxY, v.bounds.maxY)
+              }
+            };
+          }
+        }
+      }
+      return null;
+    }
+
+    function renderObjectOverlay() {
+      objectLayer.innerHTML = '';
+      detectedObjects.forEach(obj => {
+        if (obj.type === 'axes') {
+          drawSvgLine(obj.h.first, obj.h.last, 'cderive-object-axes');
+          drawSvgLine(obj.v.first, obj.v.last, 'cderive-object-axes');
+          drawSvgLabel(obj.bounds.minX, obj.bounds.minY - 16, 'axes');
+        } else if (obj.type === 'circle') {
+          const cx = obj.bounds.minX + obj.bounds.w / 2;
+          const cy = obj.bounds.minY + obj.bounds.h / 2;
+          const r = Math.max(obj.bounds.w, obj.bounds.h) / 2;
+          const el = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+          el.setAttribute('cx', String(cx));
+          el.setAttribute('cy', String(cy));
+          el.setAttribute('r', String(r));
+          el.setAttribute('class', 'cderive-object-shape');
+          objectLayer.appendChild(el);
+          drawSvgLabel(obj.bounds.minX, obj.bounds.minY - 16, 'circle');
+        } else if (obj.type === 'square') {
+          const el = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+          el.setAttribute('x', String(obj.bounds.minX));
+          el.setAttribute('y', String(obj.bounds.minY));
+          el.setAttribute('width', String(obj.bounds.w));
+          el.setAttribute('height', String(obj.bounds.h));
+          el.setAttribute('class', 'cderive-object-shape');
+          objectLayer.appendChild(el);
+          drawSvgLabel(obj.bounds.minX, obj.bounds.minY - 16, 'square');
+        }
+      });
+    }
+
+    function drawSvgLine(a, b, className) {
+      const el = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+      el.setAttribute('x1', String(a.x));
+      el.setAttribute('y1', String(a.y));
+      el.setAttribute('x2', String(b.x));
+      el.setAttribute('y2', String(b.y));
+      el.setAttribute('class', className);
+      objectLayer.appendChild(el);
+    }
+
+    function drawSvgLabel(x, y, label) {
+      const el = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+      el.setAttribute('x', String(Math.max(12, x)));
+      el.setAttribute('y', String(Math.max(22, y)));
+      el.setAttribute('class', 'cderive-object-label');
+      el.textContent = label;
+      objectLayer.appendChild(el);
     }
 
     // Progressive hints (question -> direction -> worked first step).

--- a/app.js
+++ b/app.js
@@ -3525,7 +3525,11 @@ plt.close('all')
     });
 
     if (completedBlockId && activeBlock && lesson.demo_mode.auto_advance) {
-      const nextEl = document.getElementById('block-' + activeBlock.id);
+      const completedIdx = lesson.blocks.findIndex(b => b.id === completedBlockId);
+      const nextBlock = completedIdx >= 0
+        ? lesson.blocks.slice(completedIdx + 1).find(b => !blockState[b.id] || !blockState[b.id].completed)
+        : null;
+      const nextEl = document.getElementById('block-' + (nextBlock ? nextBlock.id : activeBlock.id));
       const completedEl = document.getElementById('block-' + completedBlockId);
       if (nextEl && completedEl) {
         const scrollAfterPulse = event => {

--- a/app.js
+++ b/app.js
@@ -3525,11 +3525,7 @@ plt.close('all')
     });
 
     if (completedBlockId && activeBlock && lesson.demo_mode.auto_advance) {
-      const completedIdx = lesson.blocks.findIndex(b => b.id === completedBlockId);
-      const nextBlock = completedIdx >= 0
-        ? lesson.blocks.slice(completedIdx + 1).find(b => !blockState[b.id] || !blockState[b.id].completed)
-        : null;
-      const nextEl = document.getElementById('block-' + (nextBlock ? nextBlock.id : activeBlock.id));
+      const nextEl = document.getElementById('block-' + activeBlock.id);
       const completedEl = document.getElementById('block-' + completedBlockId);
       if (nextEl && completedEl) {
         const scrollAfterPulse = event => {

--- a/lessons/demo/interactive-derivation-canvas.json
+++ b/lessons/demo/interactive-derivation-canvas.json
@@ -1,7 +1,7 @@
 {
   "lesson_id": "DEMO-CANVAS",
   "title": "Interactive Derivation Canvas Demo",
-  "description": "A short practice ladder of handwritten derivations that ramps from algebra to physics and keeps a running score.",
+  "description": "A six-round practice demo that ramps from algebra to physics while keeping score.",
   "prerequisites": [],
   "demo_mode": {
     "enabled": true,
@@ -12,17 +12,17 @@
     {
       "id": "DEMO-INTRO",
       "type": "read",
-      "title": "Practice ladder",
-      "content_html": "<p>Four short rounds. Start with a one-line algebra warm-up, then reuse the same moves in progressively more physical equations.</p>"
+      "title": "Practice rounds",
+      "content_html": "<p>Six short canvas rounds. Each round adds one move.</p>"
     },
     {
-      "id": "DEMO-LINEAR",
+      "id": "DEMO-SUBTRACT",
       "type": "canvas-derive",
-      "title": "Warm-up: isolate x",
+      "title": "One move",
       "demo_step": 1,
       "demo_difficulty": "Warm-up",
-      "demo_points": 50,
-      "prompt": "Start with one clean algebra move: isolate x.",
+      "demo_points": 40,
+      "prompt": "Subtract 3 from both sides.",
       "starting_equation": "x + 3 = 10",
       "target_equation": "x = 7",
       "target_forms": [
@@ -37,18 +37,71 @@
       ],
       "vars": ["x"],
       "hints": [
-        "Undo the +3 by subtracting 3 from both sides.",
+        "Undo the +3 by subtracting 3.",
         "10 - 3 = 7."
+      ]
+    },
+    {
+      "id": "DEMO-TWO-STEP",
+      "type": "canvas-derive",
+      "title": "Two moves",
+      "demo_step": 2,
+      "demo_difficulty": "Algebra",
+      "demo_points": 60,
+      "prompt": "Clear the constant, then divide.",
+      "starting_equation": "2x + 6 = 20",
+      "target_equation": "x = 7",
+      "target_forms": [
+        "x = 7",
+        "7 = x"
+      ],
+      "valid_forms": [
+        "2x + 6 = 20",
+        "2x = 20 - 6",
+        "2x = 14",
+        "x = 7",
+        "7 = x"
+      ],
+      "vars": ["x"],
+      "hints": [
+        "Subtract 6 first.",
+        "Then divide both sides by 2."
+      ]
+    },
+    {
+      "id": "DEMO-SQUARE-ROOT",
+      "type": "canvas-derive",
+      "title": "Square root",
+      "demo_step": 3,
+      "demo_difficulty": "Algebra",
+      "demo_points": 75,
+      "prompt": "Take the positive square root.",
+      "starting_equation": "v^2 = 49",
+      "target_equation": "v = 7",
+      "target_forms": [
+        "v = 7",
+        "7 = v"
+      ],
+      "valid_forms": [
+        "v^2 = 49",
+        "v = \\sqrt{49}",
+        "v = 7",
+        "7 = v"
+      ],
+      "vars": ["v"],
+      "hints": [
+        "A speed uses the positive root.",
+        "sqrt(49) = 7."
       ]
     },
     {
       "id": "DEMO-KINETIC",
       "type": "canvas-derive",
-      "title": "Add a square root",
-      "demo_step": 2,
-      "demo_difficulty": "Algebra",
-      "demo_points": 75,
-      "prompt": "Same idea, more symbols: solve the kinetic-energy equation for v.",
+      "title": "Speed from energy",
+      "demo_step": 4,
+      "demo_difficulty": "Symbols",
+      "demo_points": 90,
+      "prompt": "Use the same square-root move with symbols.",
       "starting_equation": "E = \\frac{1}{2} m v^2",
       "target_equation": "v = \\sqrt{\\frac{2E}{m}}",
       "target_forms": [
@@ -66,18 +119,18 @@
       "vars": ["E", "m", "v"],
       "hints": [
         "Multiply both sides by 2.",
-        "Divide by m so v^2 is alone.",
-        "Use the positive square root for speed."
+        "Divide by m.",
+        "Take the positive square root."
       ]
     },
     {
       "id": "DEMO-SPRING",
       "type": "canvas-derive",
       "title": "Spring launch speed",
-      "demo_step": 3,
+      "demo_step": 5,
       "demo_difficulty": "Energy",
-      "demo_points": 100,
-      "prompt": "Reuse the square-root move to derive launch speed from spring energy.",
+      "demo_points": 115,
+      "prompt": "Apply the same pattern to spring energy.",
       "starting_equation": "\\frac{1}{2} k A^2 = \\frac{1}{2} m v^2",
       "target_equation": "v = A\\sqrt{\\frac{k}{m}}",
       "target_forms": [
@@ -96,19 +149,19 @@
       ],
       "vars": ["k", "A", "m", "v"],
       "hints": [
-        "Cancel the 1/2 on both sides first.",
-        "Divide by m to isolate v^2.",
-        "Take the positive square root. Since A is an amplitude, use A > 0."
+        "Cancel the 1/2 first.",
+        "Divide by m.",
+        "Take the positive square root."
       ]
     },
     {
       "id": "DEMO-LOOP",
       "type": "canvas-derive",
-      "title": "Final challenge: loop threshold",
-      "demo_step": 4,
+      "title": "Loop threshold",
+      "demo_step": 6,
       "demo_difficulty": "Challenge",
       "demo_points": 150,
-      "prompt": "Put the earlier moves together. Derive the minimum release height for a loop-the-loop.",
+      "prompt": "Final round: use force for v^2, then energy for h.",
       "starting_equation": "mg = \\frac{m v^2}{R}",
       "target_equation": "h = \\frac{5R}{2}",
       "target_forms": [
@@ -132,8 +185,8 @@
       ],
       "vars": ["m", "g", "v", "R", "h"],
       "hints": [
-        "Use the force equation first to get v^2 = gR.",
-        "At the top, the ball is at height 2R, so its potential energy is mg(2R).",
+        "Cancel m in the force equation.",
+        "Multiply by R to get v^2 = gR.",
         "Use 1/2 m v^2 + mg(2R) = mgh.",
         "Substitute v^2 = gR, then cancel m and g."
       ]

--- a/lessons/demo/interactive-derivation-canvas.json
+++ b/lessons/demo/interactive-derivation-canvas.json
@@ -1,7 +1,7 @@
 {
   "lesson_id": "DEMO-CANVAS",
-  "title": "Interactive Derivation Canvas Demo",
-  "description": "A short recording-ready sequence of handwritten derivations that ramps from algebra to physics and keeps a running score.",
+  "title": "Spring Loop Derivation Canvas Demo",
+  "description": "A recording-ready sequence of handwritten derivations where each result feeds the next step of a spring-loaded loop-the-loop design.",
   "prerequisites": [],
   "demo_mode": {
     "enabled": true,
@@ -12,104 +12,86 @@
     {
       "id": "DEMO-INTRO",
       "type": "read",
-      "title": "Derivation sprint",
-      "content_html": "<p>Four handwritten challenges build into one clean physics result. Each canvas reads your lines, marks valid equations, and adds points when you reach the target.</p><p>The sequence starts with a one-line algebra move, then isolates a square-root quantity, then derives a spring launch speed, then finishes with the loop-the-loop threshold.</p>"
+      "title": "One connected derivation",
+      "content_html": "<p>The goal is to design a spring launch that barely carries a cart through a vertical loop. Each canvas reads your handwritten lines, marks valid equations, and adds points when you reach the target.</p><p>The first derivation finds the required speed at the top of the loop. The next turns energy into a release height. Then you combine those two results and finish by sizing the spring compression.</p>"
     },
     {
-      "id": "DEMO-LINEAR",
+      "id": "DEMO-TOP-SPEED",
       "type": "canvas-derive",
-      "title": "Calibrate the canvas",
+      "title": "Top-of-loop speed",
       "demo_step": 1,
       "demo_difficulty": "Warm-up",
       "demo_points": 50,
-      "prompt": "Start from the calibration equation and isolate x.",
-      "starting_equation": "x + 3 = 10",
-      "target_equation": "x = 7",
+      "prompt": "At the top of the loop, the minimum-speed case has gravity supplying the centripetal force. Isolate v^2.",
+      "context_note": "<strong>Carry forward:</strong> this result becomes the speed condition used in the height derivation.",
+      "starting_equation": "mg = \\frac{m v^2}{R}",
+      "target_equation": "v^2 = gR",
       "target_forms": [
-        "x = 7",
-        "7 = x"
+        "v^2 = gR",
+        "v^2 = g R",
+        "gR = v^2"
       ],
       "valid_forms": [
-        "x + 3 = 10",
-        "x = 10 - 3",
-        "x = 7",
-        "7 = x"
+        "mg = \\frac{m v^2}{R}",
+        "g = \\frac{v^2}{R}",
+        "Rg = v^2",
+        "gR = v^2",
+        "v^2 = gR",
+        "v^2 = g R"
       ],
-      "vars": ["x"],
+      "vars": ["m", "g", "v", "R"],
       "hints": [
-        "Undo the +3 by subtracting 3 from both sides.",
-        "10 - 3 = 7."
+        "Cancel m on both sides.",
+        "Multiply both sides by R.",
+        "Rewrite with v^2 on the left."
       ]
     },
     {
-      "id": "DEMO-KINETIC",
+      "id": "DEMO-HEIGHT-BALANCE",
       "type": "canvas-derive",
-      "title": "Unlock a square root",
+      "title": "Height as stored energy",
       "demo_step": 2,
       "demo_difficulty": "Algebra",
       "demo_points": 75,
-      "prompt": "A later physics problem will need speed from energy. Solve the kinetic-energy equation for v.",
-      "starting_equation": "E = \\frac{1}{2} m v^2",
-      "target_equation": "v = \\sqrt{\\frac{2E}{m}}",
+      "prompt": "Use conservation of energy from release height h to the top of the loop, then solve for h in terms of v^2.",
+      "context_note": "<strong>Carry forward:</strong> the previous canvas gave v^2 = gR. Do not substitute it yet; first make a clean height formula.",
+      "starting_equation": "mgh = \\frac{1}{2} m v^2 + mg(2R)",
+      "target_equation": "h = \\frac{v^2}{2g} + 2R",
       "target_forms": [
-        "v = \\sqrt{\\frac{2E}{m}}",
-        "v = \\sqrt{2E/m}"
+        "h = \\frac{v^2}{2g} + 2R",
+        "h = 2R + \\frac{v^2}{2g}"
       ],
       "valid_forms": [
-        "E = \\frac{1}{2} m v^2",
-        "2E = m v^2",
-        "\\frac{2E}{m} = v^2",
-        "v^2 = \\frac{2E}{m}",
-        "v = \\sqrt{\\frac{2E}{m}}",
-        "v = \\sqrt{2E/m}"
+        "mgh = \\frac{1}{2} m v^2 + mg(2R)",
+        "gh = \\frac{1}{2} v^2 + g(2R)",
+        "gh = \\frac{1}{2} v^2 + 2gR",
+        "h = \\frac{1}{2g} v^2 + 2R",
+        "h = \\frac{v^2}{2g} + 2R",
+        "h = 2R + \\frac{v^2}{2g}"
       ],
-      "vars": ["E", "m", "v"],
+      "vars": ["m", "g", "h", "v", "R"],
       "hints": [
-        "Multiply both sides by 2.",
-        "Divide by m so v^2 is alone.",
-        "Use the positive square root for speed."
+        "Cancel m from every term.",
+        "Divide the whole equation by g.",
+        "Leave v^2 in the formula so the top-speed result can drop in next."
       ]
     },
     {
-      "id": "DEMO-SPRING",
+      "id": "DEMO-BRIDGE-HEIGHT",
+      "type": "read",
+      "title": "Now connect the two results",
+      "content_html": "<p>The first canvas produced <strong>v<sup>2</sup> = gR</strong>. The second produced <strong>h = v<sup>2</sup>/(2g) + 2R</strong>. The next canvas is the payoff: substitute the required top speed and simplify the minimum release height.</p>"
+    },
+    {
+      "id": "DEMO-LOOP-HEIGHT",
       "type": "canvas-derive",
-      "title": "Spring launch speed",
+      "title": "Minimum release height",
       "demo_step": 3,
       "demo_difficulty": "Energy",
       "demo_points": 100,
-      "prompt": "Now use the same square-root move to derive the launch speed from a compressed spring.",
-      "starting_equation": "\\frac{1}{2} k A^2 = \\frac{1}{2} m v^2",
-      "target_equation": "v = A\\sqrt{\\frac{k}{m}}",
-      "target_forms": [
-        "v = A\\sqrt{\\frac{k}{m}}",
-        "v = A \\sqrt{k/m}",
-        "v = \\sqrt{\\frac{k A^2}{m}}"
-      ],
-      "valid_forms": [
-        "\\frac{1}{2} k A^2 = \\frac{1}{2} m v^2",
-        "k A^2 = m v^2",
-        "\\frac{k A^2}{m} = v^2",
-        "v^2 = \\frac{k A^2}{m}",
-        "v = \\sqrt{\\frac{k A^2}{m}}",
-        "v = A\\sqrt{\\frac{k}{m}}",
-        "v = A \\sqrt{k/m}"
-      ],
-      "vars": ["k", "A", "m", "v"],
-      "hints": [
-        "Cancel the 1/2 on both sides first.",
-        "Divide by m to isolate v^2.",
-        "Take the positive square root. Since A is an amplitude, use A > 0."
-      ]
-    },
-    {
-      "id": "DEMO-LOOP",
-      "type": "canvas-derive",
-      "title": "Loop-the-loop threshold",
-      "demo_step": 4,
-      "demo_difficulty": "Challenge",
-      "demo_points": 150,
-      "prompt": "Finish with the classic loop threshold. At the top of the loop, gravity supplies the centripetal force: mg = m v^2 / R. Energy from height h becomes kinetic energy plus height 2R at the top. Derive the minimum h.",
-      "starting_equation": "mg = \\frac{m v^2}{R}",
+      "prompt": "Substitute the top-of-loop speed condition into the height formula and simplify h.",
+      "context_note": "<strong>Carry forward:</strong> this height threshold is the amount of gravitational energy the launch spring must provide.",
+      "starting_equation": "h = \\frac{gR}{2g} + 2R",
       "target_equation": "h = \\frac{5R}{2}",
       "target_forms": [
         "h = \\frac{5R}{2}",
@@ -117,25 +99,49 @@
         "h = 2.5R"
       ],
       "valid_forms": [
-        "mg = \\frac{m v^2}{R}",
-        "g = \\frac{v^2}{R}",
-        "v^2 = gR",
-        "\\frac{1}{2} m v^2 + m g (2R) = m g h",
-        "\\frac{1}{2} v^2 + 2 g R = g h",
-        "\\frac{1}{2} (gR) + 2gR = gh",
-        "\\frac{1}{2} gR + 2gR = gh",
-        "\\frac{5}{2} g R = g h",
-        "\\frac{5}{2} R = h",
+        "h = \\frac{gR}{2g} + 2R",
+        "h = \\frac{R}{2} + 2R",
+        "h = \\frac{R}{2} + \\frac{4R}{2}",
         "h = \\frac{5R}{2}",
-        "h = \\frac{5}{2} R",
-        "h = 2.5 R"
+        "h = \\frac{5}{2}R",
+        "h = 2.5R"
       ],
-      "vars": ["m", "g", "v", "R", "h"],
+      "vars": ["g", "R", "h"],
       "hints": [
-        "Use the force equation first to get v^2 = gR.",
-        "At the top, the ball is at height 2R, so its potential energy is mg(2R).",
-        "Use 1/2 m v^2 + mg(2R) = mgh.",
-        "Substitute v^2 = gR, then cancel m and g."
+        "Cancel g in gR/(2g).",
+        "Write 2R as 4R/2.",
+        "Add the two R terms."
+      ]
+    },
+    {
+      "id": "DEMO-SPRING-SIZE",
+      "type": "canvas-derive",
+      "title": "Spring compression",
+      "demo_step": 4,
+      "demo_difficulty": "Challenge",
+      "demo_points": 150,
+      "prompt": "Finish the design. Set the spring energy equal to the gravitational energy needed for the release height h = 5R/2, then solve for the compression A.",
+      "context_note": "<strong>Final link:</strong> the loop threshold from the previous canvas becomes the design requirement for the spring.",
+      "starting_equation": "\\frac{1}{2} k A^2 = mg\\left(\\frac{5R}{2}\\right)",
+      "target_equation": "A = \\sqrt{\\frac{5mgR}{k}}",
+      "target_forms": [
+        "A = \\sqrt{\\frac{5mgR}{k}}",
+        "A = \\sqrt{5mgR/k}"
+      ],
+      "valid_forms": [
+        "\\frac{1}{2} k A^2 = mg\\left(\\frac{5R}{2}\\right)",
+        "\\frac{1}{2} k A^2 = \\frac{5mgR}{2}",
+        "k A^2 = 5mgR",
+        "A^2 = \\frac{5mgR}{k}",
+        "A = \\sqrt{\\frac{5mgR}{k}}",
+        "A = \\sqrt{5mgR/k}"
+      ],
+      "vars": ["k", "A", "m", "g", "R"],
+      "hints": [
+        "First simplify the right side to 5mgR/2.",
+        "Multiply both sides by 2.",
+        "Divide by k.",
+        "Take the positive square root because compression is a length."
       ]
     }
   ]

--- a/lessons/demo/interactive-derivation-canvas.json
+++ b/lessons/demo/interactive-derivation-canvas.json
@@ -1,7 +1,7 @@
 {
   "lesson_id": "DEMO-CANVAS",
-  "title": "Spring Loop Derivation Canvas Demo",
-  "description": "A recording-ready sequence of handwritten derivations where each result feeds the next step of a spring-loaded loop-the-loop design.",
+  "title": "Interactive Derivation Canvas Demo",
+  "description": "A short practice ladder of handwritten derivations that ramps from algebra to physics and keeps a running score.",
   "prerequisites": [],
   "demo_mode": {
     "enabled": true,
@@ -12,86 +12,104 @@
     {
       "id": "DEMO-INTRO",
       "type": "read",
-      "title": "One connected derivation",
-      "content_html": "<p>The goal is to design a spring launch that barely carries a cart through a vertical loop. Each canvas reads your handwritten lines, marks valid equations, and adds points when you reach the target.</p><p>The first derivation finds the required speed at the top of the loop. The next turns energy into a release height. Then you combine those two results and finish by sizing the spring compression.</p>"
+      "title": "Practice ladder",
+      "content_html": "<p>Four short rounds. Start with a one-line algebra warm-up, then reuse the same moves in progressively more physical equations.</p>"
     },
     {
-      "id": "DEMO-TOP-SPEED",
+      "id": "DEMO-LINEAR",
       "type": "canvas-derive",
-      "title": "Top-of-loop speed",
+      "title": "Warm-up: isolate x",
       "demo_step": 1,
       "demo_difficulty": "Warm-up",
       "demo_points": 50,
-      "prompt": "At the top of the loop, the minimum-speed case has gravity supplying the centripetal force. Isolate v^2.",
-      "context_note": "<strong>Carry forward:</strong> this result becomes the speed condition used in the height derivation.",
-      "starting_equation": "mg = \\frac{m v^2}{R}",
-      "target_equation": "v^2 = gR",
+      "prompt": "Start with one clean algebra move: isolate x.",
+      "starting_equation": "x + 3 = 10",
+      "target_equation": "x = 7",
       "target_forms": [
-        "v^2 = gR",
-        "v^2 = g R",
-        "gR = v^2"
+        "x = 7",
+        "7 = x"
       ],
       "valid_forms": [
-        "mg = \\frac{m v^2}{R}",
-        "g = \\frac{v^2}{R}",
-        "Rg = v^2",
-        "gR = v^2",
-        "v^2 = gR",
-        "v^2 = g R"
+        "x + 3 = 10",
+        "x = 10 - 3",
+        "x = 7",
+        "7 = x"
       ],
-      "vars": ["m", "g", "v", "R"],
+      "vars": ["x"],
       "hints": [
-        "Cancel m on both sides.",
-        "Multiply both sides by R.",
-        "Rewrite with v^2 on the left."
+        "Undo the +3 by subtracting 3 from both sides.",
+        "10 - 3 = 7."
       ]
     },
     {
-      "id": "DEMO-HEIGHT-BALANCE",
+      "id": "DEMO-KINETIC",
       "type": "canvas-derive",
-      "title": "Height as stored energy",
+      "title": "Add a square root",
       "demo_step": 2,
       "demo_difficulty": "Algebra",
       "demo_points": 75,
-      "prompt": "Use conservation of energy from release height h to the top of the loop, then solve for h in terms of v^2.",
-      "context_note": "<strong>Carry forward:</strong> the previous canvas gave v^2 = gR. Do not substitute it yet; first make a clean height formula.",
-      "starting_equation": "mgh = \\frac{1}{2} m v^2 + mg(2R)",
-      "target_equation": "h = \\frac{v^2}{2g} + 2R",
+      "prompt": "Same idea, more symbols: solve the kinetic-energy equation for v.",
+      "starting_equation": "E = \\frac{1}{2} m v^2",
+      "target_equation": "v = \\sqrt{\\frac{2E}{m}}",
       "target_forms": [
-        "h = \\frac{v^2}{2g} + 2R",
-        "h = 2R + \\frac{v^2}{2g}"
+        "v = \\sqrt{\\frac{2E}{m}}",
+        "v = \\sqrt{2E/m}"
       ],
       "valid_forms": [
-        "mgh = \\frac{1}{2} m v^2 + mg(2R)",
-        "gh = \\frac{1}{2} v^2 + g(2R)",
-        "gh = \\frac{1}{2} v^2 + 2gR",
-        "h = \\frac{1}{2g} v^2 + 2R",
-        "h = \\frac{v^2}{2g} + 2R",
-        "h = 2R + \\frac{v^2}{2g}"
+        "E = \\frac{1}{2} m v^2",
+        "2E = m v^2",
+        "\\frac{2E}{m} = v^2",
+        "v^2 = \\frac{2E}{m}",
+        "v = \\sqrt{\\frac{2E}{m}}",
+        "v = \\sqrt{2E/m}"
       ],
-      "vars": ["m", "g", "h", "v", "R"],
+      "vars": ["E", "m", "v"],
       "hints": [
-        "Cancel m from every term.",
-        "Divide the whole equation by g.",
-        "Leave v^2 in the formula so the top-speed result can drop in next."
+        "Multiply both sides by 2.",
+        "Divide by m so v^2 is alone.",
+        "Use the positive square root for speed."
       ]
     },
     {
-      "id": "DEMO-BRIDGE-HEIGHT",
-      "type": "read",
-      "title": "Now connect the two results",
-      "content_html": "<p>The first canvas produced <strong>v<sup>2</sup> = gR</strong>. The second produced <strong>h = v<sup>2</sup>/(2g) + 2R</strong>. The next canvas is the payoff: substitute the required top speed and simplify the minimum release height.</p>"
-    },
-    {
-      "id": "DEMO-LOOP-HEIGHT",
+      "id": "DEMO-SPRING",
       "type": "canvas-derive",
-      "title": "Minimum release height",
+      "title": "Spring launch speed",
       "demo_step": 3,
       "demo_difficulty": "Energy",
       "demo_points": 100,
-      "prompt": "Substitute the top-of-loop speed condition into the height formula and simplify h.",
-      "context_note": "<strong>Carry forward:</strong> this height threshold is the amount of gravitational energy the launch spring must provide.",
-      "starting_equation": "h = \\frac{gR}{2g} + 2R",
+      "prompt": "Reuse the square-root move to derive launch speed from spring energy.",
+      "starting_equation": "\\frac{1}{2} k A^2 = \\frac{1}{2} m v^2",
+      "target_equation": "v = A\\sqrt{\\frac{k}{m}}",
+      "target_forms": [
+        "v = A\\sqrt{\\frac{k}{m}}",
+        "v = A \\sqrt{k/m}",
+        "v = \\sqrt{\\frac{k A^2}{m}}"
+      ],
+      "valid_forms": [
+        "\\frac{1}{2} k A^2 = \\frac{1}{2} m v^2",
+        "k A^2 = m v^2",
+        "\\frac{k A^2}{m} = v^2",
+        "v^2 = \\frac{k A^2}{m}",
+        "v = \\sqrt{\\frac{k A^2}{m}}",
+        "v = A\\sqrt{\\frac{k}{m}}",
+        "v = A \\sqrt{k/m}"
+      ],
+      "vars": ["k", "A", "m", "v"],
+      "hints": [
+        "Cancel the 1/2 on both sides first.",
+        "Divide by m to isolate v^2.",
+        "Take the positive square root. Since A is an amplitude, use A > 0."
+      ]
+    },
+    {
+      "id": "DEMO-LOOP",
+      "type": "canvas-derive",
+      "title": "Final challenge: loop threshold",
+      "demo_step": 4,
+      "demo_difficulty": "Challenge",
+      "demo_points": 150,
+      "prompt": "Put the earlier moves together. Derive the minimum release height for a loop-the-loop.",
+      "starting_equation": "mg = \\frac{m v^2}{R}",
       "target_equation": "h = \\frac{5R}{2}",
       "target_forms": [
         "h = \\frac{5R}{2}",
@@ -99,49 +117,25 @@
         "h = 2.5R"
       ],
       "valid_forms": [
-        "h = \\frac{gR}{2g} + 2R",
-        "h = \\frac{R}{2} + 2R",
-        "h = \\frac{R}{2} + \\frac{4R}{2}",
+        "mg = \\frac{m v^2}{R}",
+        "g = \\frac{v^2}{R}",
+        "v^2 = gR",
+        "\\frac{1}{2} m v^2 + m g (2R) = m g h",
+        "\\frac{1}{2} v^2 + 2 g R = g h",
+        "\\frac{1}{2} (gR) + 2gR = gh",
+        "\\frac{1}{2} gR + 2gR = gh",
+        "\\frac{5}{2} g R = g h",
+        "\\frac{5}{2} R = h",
         "h = \\frac{5R}{2}",
-        "h = \\frac{5}{2}R",
-        "h = 2.5R"
+        "h = \\frac{5}{2} R",
+        "h = 2.5 R"
       ],
-      "vars": ["g", "R", "h"],
+      "vars": ["m", "g", "v", "R", "h"],
       "hints": [
-        "Cancel g in gR/(2g).",
-        "Write 2R as 4R/2.",
-        "Add the two R terms."
-      ]
-    },
-    {
-      "id": "DEMO-SPRING-SIZE",
-      "type": "canvas-derive",
-      "title": "Spring compression",
-      "demo_step": 4,
-      "demo_difficulty": "Challenge",
-      "demo_points": 150,
-      "prompt": "Finish the design. Set the spring energy equal to the gravitational energy needed for the release height h = 5R/2, then solve for the compression A.",
-      "context_note": "<strong>Final link:</strong> the loop threshold from the previous canvas becomes the design requirement for the spring.",
-      "starting_equation": "\\frac{1}{2} k A^2 = mg\\left(\\frac{5R}{2}\\right)",
-      "target_equation": "A = \\sqrt{\\frac{5mgR}{k}}",
-      "target_forms": [
-        "A = \\sqrt{\\frac{5mgR}{k}}",
-        "A = \\sqrt{5mgR/k}"
-      ],
-      "valid_forms": [
-        "\\frac{1}{2} k A^2 = mg\\left(\\frac{5R}{2}\\right)",
-        "\\frac{1}{2} k A^2 = \\frac{5mgR}{2}",
-        "k A^2 = 5mgR",
-        "A^2 = \\frac{5mgR}{k}",
-        "A = \\sqrt{\\frac{5mgR}{k}}",
-        "A = \\sqrt{5mgR/k}"
-      ],
-      "vars": ["k", "A", "m", "g", "R"],
-      "hints": [
-        "First simplify the right side to 5mgR/2.",
-        "Multiply both sides by 2.",
-        "Divide by k.",
-        "Take the positive square root because compression is a length."
+        "Use the force equation first to get v^2 = gR.",
+        "At the top, the ball is at height 2R, so its potential energy is mg(2R).",
+        "Use 1/2 m v^2 + mg(2R) = mgh.",
+        "Substitute v^2 = gR, then cancel m and g."
       ]
     }
   ]

--- a/lessons/demo/interactive-derivation-canvas.json
+++ b/lessons/demo/interactive-derivation-canvas.json
@@ -1,7 +1,7 @@
 {
   "lesson_id": "DEMO-CANVAS",
   "title": "Interactive Derivation Canvas Demo",
-  "description": "A six-round practice demo that ramps from algebra to physics while keeping score.",
+  "description": "A seven-round practice demo that ramps from algebra to launch height while keeping score.",
   "prerequisites": [],
   "demo_mode": {
     "enabled": true,
@@ -13,7 +13,7 @@
       "id": "DEMO-INTRO",
       "type": "read",
       "title": "Practice rounds",
-      "content_html": "<p>Six short canvas rounds. Each round adds one move.</p>"
+      "content_html": "<p>Seven short canvas rounds. Each round adds one move.</p>"
     },
     {
       "id": "DEMO-SUBTRACT",
@@ -155,40 +155,63 @@
       ]
     },
     {
-      "id": "DEMO-LOOP",
+      "id": "DEMO-HEIGHT-FROM-SPEED",
       "type": "canvas-derive",
-      "title": "Loop threshold",
+      "title": "Height from speed",
       "demo_step": 6,
-      "demo_difficulty": "Challenge",
-      "demo_points": 150,
-      "prompt": "Final round: use force for v^2, then energy for h.",
-      "starting_equation": "mg = \\frac{m v^2}{R}",
-      "target_equation": "h = \\frac{5R}{2}",
+      "demo_difficulty": "Energy",
+      "demo_points": 130,
+      "prompt": "A launch speed turns into height. Solve for h.",
+      "starting_equation": "\\frac{1}{2} m v^2 = mgh",
+      "target_equation": "h = \\frac{v^2}{2g}",
       "target_forms": [
-        "h = \\frac{5R}{2}",
-        "h = \\frac{5}{2}R",
-        "h = 2.5R"
+        "h = \\frac{v^2}{2g}",
+        "h = \\frac{1}{2g}v^2",
+        "\\frac{v^2}{2g} = h"
       ],
       "valid_forms": [
-        "mg = \\frac{m v^2}{R}",
-        "g = \\frac{v^2}{R}",
-        "v^2 = gR",
-        "\\frac{1}{2} m v^2 + m g (2R) = m g h",
-        "\\frac{1}{2} v^2 + 2 g R = g h",
-        "\\frac{1}{2} (gR) + 2gR = gh",
-        "\\frac{1}{2} gR + 2gR = gh",
-        "\\frac{5}{2} g R = g h",
-        "\\frac{5}{2} R = h",
-        "h = \\frac{5R}{2}",
-        "h = \\frac{5}{2} R",
-        "h = 2.5 R"
+        "\\frac{1}{2} m v^2 = mgh",
+        "\\frac{1}{2} v^2 = gh",
+        "\\frac{v^2}{2} = gh",
+        "h = \\frac{v^2}{2g}",
+        "h = \\frac{1}{2g}v^2",
+        "\\frac{v^2}{2g} = h"
       ],
-      "vars": ["m", "g", "v", "R", "h"],
+      "vars": ["m", "g", "v", "h"],
       "hints": [
-        "Cancel m in the force equation.",
-        "Multiply by R to get v^2 = gR.",
-        "Use 1/2 m v^2 + mg(2R) = mgh.",
-        "Substitute v^2 = gR, then cancel m and g."
+        "Cancel m first.",
+        "Write 1/2 v^2 as v^2/2.",
+        "Divide by g."
+      ]
+    },
+    {
+      "id": "DEMO-HEIGHT-FROM-SPRING",
+      "type": "canvas-derive",
+      "title": "Height from spring",
+      "demo_step": 7,
+      "demo_difficulty": "Challenge",
+      "demo_points": 150,
+      "prompt": "Now skip speed and solve directly for height.",
+      "starting_equation": "\\frac{1}{2} k A^2 = mgh",
+      "target_equation": "h = \\frac{k A^2}{2mg}",
+      "target_forms": [
+        "h = \\frac{k A^2}{2mg}",
+        "h = \\frac{kA^2}{2mg}",
+        "\\frac{k A^2}{2mg} = h"
+      ],
+      "valid_forms": [
+        "\\frac{1}{2} k A^2 = mgh",
+        "\\frac{k A^2}{2} = mgh",
+        "k A^2 = 2mgh",
+        "\\frac{k A^2}{2mg} = h",
+        "h = \\frac{k A^2}{2mg}",
+        "h = \\frac{kA^2}{2mg}"
+      ],
+      "vars": ["k", "A", "m", "g", "h"],
+      "hints": [
+        "Write the left side as kA^2/2.",
+        "Divide by mg.",
+        "Put h on the left."
       ]
     }
   ]

--- a/style.css
+++ b/style.css
@@ -1539,6 +1539,8 @@ main {
   -webkit-tap-highlight-color: transparent;
 }
 .cderive-pad {
+  position: relative;
+  z-index: 1;
   width: 100%;
   height: auto;
   display: block;
@@ -1549,6 +1551,59 @@ main {
   -webkit-user-select: none;
   -webkit-touch-callout: none;
   -webkit-tap-highlight-color: transparent;
+}
+.cderive-ghost-layer,
+.cderive-object-layer {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+.cderive-ghost-layer {
+  z-index: 0;
+  display: none;
+  padding: 26px;
+  color: rgba(55, 65, 81, 0.34);
+}
+.cderive-ghost-layer.active {
+  display: block;
+}
+.cderive-ghost-card {
+  max-width: 45%;
+  padding: 12px 16px;
+  border: 1px solid rgba(107, 114, 128, 0.16);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.42);
+}
+.cderive-ghost-line {
+  opacity: 0.62;
+}
+.cderive-ghost-line .katex-display {
+  margin: 0.15em 0;
+}
+.cderive-object-layer {
+  z-index: 2;
+  overflow: visible;
+}
+.cderive-object-shape,
+.cderive-object-axes {
+  vector-effect: non-scaling-stroke;
+  fill: rgba(37, 99, 235, 0.06);
+  stroke: rgba(37, 99, 235, 0.82);
+  stroke-width: 4;
+  stroke-dasharray: 12 8;
+}
+.cderive-object-axes {
+  fill: none;
+  stroke: rgba(22, 163, 74, 0.9);
+}
+.cderive-object-label {
+  font: 700 28px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  fill: rgba(31, 41, 55, 0.72);
+  paint-order: stroke;
+  stroke: rgba(255, 255, 255, 0.9);
+  stroke-width: 6;
 }
 .cderive-controls {
   display: flex;


### PR DESCRIPTION
## Summary
- Expand the promo canvas demo into seven scored practice rounds
- Replace loop-threshold background knowledge with launch-height derivations
- Add post-solve canvas ghosting: solved derivations pin into the canvas background
- Add first same-canvas object recognition hooks for circles, squares, and coordinate axes after a derivation is solved

## Tests
- npm test
- node --check app.js
- git diff --check
- Local HTTP check on http://127.0.0.1:8766